### PR TITLE
Infer correct line height

### DIFF
--- a/src/main/java/me/rozza/uriquotes/UriQuotesPlugin.java
+++ b/src/main/java/me/rozza/uriquotes/UriQuotesPlugin.java
@@ -18,6 +18,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
+import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
 @PluginDescriptor(
@@ -104,6 +105,20 @@ public class UriQuotesPlugin extends Plugin {
 		loadQuotes();
 		String quote = this.quotes.get(this.rng.nextInt(this.quotes.size()));
 		widget.setText(quote);
+		widget.setLineHeight(this.getLineHeight(quote));
+	}
+
+	private int getLineHeight(final String text)
+	{
+		final int count = StringUtils.countMatches(text, "<br>");
+
+		if (count == 1) {
+			return 28;
+		} else if (count == 2) {
+			return 20;
+		}
+
+		return 16;
 	}
 
 	@Provides

--- a/src/main/java/me/rozza/uriquotes/UriQuotesPlugin.java
+++ b/src/main/java/me/rozza/uriquotes/UriQuotesPlugin.java
@@ -7,8 +7,8 @@ import me.rozza.uriquotes.retrievers.QuoteRetriever;
 import net.runelite.api.Client;
 import net.runelite.api.events.*;
 import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetID;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
@@ -68,7 +68,7 @@ public class UriQuotesPlugin extends Plugin {
 
 	@Subscribe
 	public void onWidgetLoaded(WidgetLoaded event) throws Exception {
-		if (event.getGroupId() == WidgetID.DIALOG_NPC_GROUP_ID) {
+		if (event.getGroupId() == InterfaceID.DIALOG_NPC) {
 			this.queueUriQuote = true;
 		}
 	}


### PR DESCRIPTION
This is a bit of a nitpick but you might notice that some dialogue doesn't quite use the correct spacing. Compare:
![Capture1](https://github.com/rozzan/uri-quotes/assets/32613991/3f0a2993-c4ec-4cd6-88e9-ca5033b82a59)
![Capture2](https://github.com/rozzan/uri-quotes/assets/32613991/957800eb-a1b3-4e30-ba99-5265203fc435)

In the second picture the lines are closer together.

This is because the line-height of a chatbox varies depending on the amount of lines.
This PR attempts to fix that by counting the amount of line-breaks used. Of course, this won't help for text that doesn't use any line breaks but it's the best way to check I think?
![Capture3](https://github.com/rozzan/uri-quotes/assets/32613991/323dbb87-ca48-4682-bedb-987abc1b420f)

